### PR TITLE
Updated Version,SHA and dependency for v2.0.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - pip
     - python
     - setuptools
+    - wheel
 
   run:
     - python
@@ -37,6 +38,10 @@ requirements:
 test:
   imports:
     - spyder_kernels
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://www.spyder-ide.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "spyder-kernels" %}
-{% set version = "2.0.1" %}
-{% set hash = "d69ca78e10b6783b506139668847368c7ace6676a771d75efd826d239597c1e9" %}
+{% set version = "2.0.3" %}
+{% set hash = "827dca9f82c3aa9ba34ac60236d8f18c0575b1bf04e19d86b16bccb876d3b35c" %}
 
 package:
   name: {{ name|lower }}
@@ -27,6 +27,7 @@ requirements:
   run:
     - python
     - cloudpickle
+    - decorator <5
     - ipykernel >=5.1.3
     - ipython >=7.6.0
     - jupyter_client >=5.3.4


### PR DESCRIPTION
Updated Version,SHA and dependency for v2.0.3 in Meta.yaml.
Category: anaconda
Version change: bump from 2.0.1 to 2.0.3
Changelog: https://github.com/spyder-ide/spyder-kernels/blob/master/CHANGELOG.md
Upstream Issues: https://github.com/spyder-ide/spyder-kernels/issues
Requirements https://github.com/spyder-ide/spyder-kernels/blob/master/setup.py
License : https://github.com/spyder-ide/spyder-kernels/blob/master/LICENSE.txt
The package builds correctly on concourse.
