### PR TITLE
Update to v2.0.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,6 @@ requirements:
   run:
     - python
     - cloudpickle
-    - decorator <5
     - ipykernel >=5.3.0
     - ipython >=7.6.0
     - jupyter_client >=5.3.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "spyder-kernels" %}
-{% set version = "2.0.1" %}
-{% set hash = "d69ca78e10b6783b506139668847368c7ace6676a771d75efd826d239597c1e9" %}
+{% set version = "2.0.5" %}
+{% set hash = "4428a9aa8f94987f366fad3afda427933a131cca5fd9c361c8553c564eae011e" %}
 
 package:
   name: {{ name|lower }}
@@ -18,16 +18,16 @@ build:
 requirements:
   build:
     - python                                 # [build_platform != target_platform]
-
   host:
     - pip
     - python
     - setuptools
-
+    - wheel
   run:
     - python
     - cloudpickle
-    - ipykernel >=5.1.3
+    - decorator <5
+    - ipykernel >=5.3.0
     - ipython >=7.6.0
     - jupyter_client >=5.3.4
     - pyzmq >=17
@@ -36,6 +36,10 @@ requirements:
 test:
   imports:
     - spyder_kernels
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://www.spyder-ide.org/


### PR DESCRIPTION
build_cadence: manual
Category:  anaconda | subcategory:   | pkg_type:  python
Popularity:  605808 downloads -  spyder-kernels  2.0.5  Jupyter kernels for Spyder's console  
Requirements from conda-forge: https://github.com/conda-forge/spyder-kernels-feedstock/blob/master/recipe/meta.yaml
Concourse builds correctly
  license: MIT
Release date:  Jul 3, 2021
Bug Tracker: new open issues https://github.com/spyder-ide/spyder-kernels/issues
Upstream license: https://github.com/spyder-ide/spyder-kernels/blob/master/LICENSE.txt
Upstream Changelog: https://github.com/spyder-ide/spyder-kernels/blob/master/CHANGELOG.md
Upstream setup.py:  https://github.com/spyder-ide/spyder-kernels/blob/master/setup.py

The package spyder-kernels is mentioned inside the packages:
spyder 

Actions:
1. Update version number and SHA256
2. Update dependencies: ipykernel >=5.3.0

Result:
- all-succeeded