### PR TITLE
spyder-kernels 2.4.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "spyder-kernels" %}
-{% set version = "2.4.1" %}
-{% set hash = "783d8dfbd715cd97728e913916779b37cf8e96566355ebdacfe3411d2beb4796" %}
+{% set version = "2.4.2" %}
+{% set hash = "97586eabda1f714c26035b5b01ed7c2e3f539b0de76bd479af5003f5f19b3eb7" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
**Recipe directory diff between current master and this update:**
``` diff
diff --git a/recipe/meta.yaml b/recipe/meta.yaml
index e262878..0557fc8 100644
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "spyder-kernels" %}
-{% set version = "2.4.1" %}
-{% set hash = "783d8dfbd715cd97728e913916779b37cf8e96566355ebdacfe3411d2beb4796" %}
+{% set version = "2.4.2" %}
+{% set hash = "97586eabda1f714c26035b5b01ed7c2e3f539b0de76bd479af5003f5f19b3eb7" %}
 
 package:
   name: {{ name|lower }}

```

**Jira ticket:** [PKG-1003
PKG-962
PKG-733](https://anaconda.atlassian.net/browse/PKG-1003
https://anaconda.atlassian.net/browse/PKG-962
https://anaconda.atlassian.net/browse/PKG-733) (spyder-kernels
spyder-kernels
spyder-kernels-2.4.2
2.4.1
2.4.0)

**The upstream data:**
Github releases:  https://github.com/spyder-ide/spyder-kernels/releases
[Diff between the latest and previous upstream releases](https://github.com/spyder-ide/spyder-kernels/compare/2.3.3...2.4.2)
License: https://github.com/spyder-ide/spyder-kernels/blob/master/LICENSE.txt
Changelog: https://github.com/spyder-ide/spyder-kernels/blob/master/CHANGELOG.md
Requirements:
 * setup.py:  https://github.com/spyder-ide/spyder-kernels/blob/v2.4.2/setup.py

**_Actions:_**

1. 

**_Notes:_**
 * 

**Additional info:**

<details>

**Package's statistics**

<details>

build_cadence: manual
 * Priority B | effort: easy | Category: anaconda | subcategory:  | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 2.4.2
 * Release on PyPi:
    * version: 2.4.2
    * date: 2023-01-17T23:17:22
* [PyPi history](https://pypi.org/project/spyder-kernels/#history)
 * Popularity: 
    * 3 months downloads: 524631.0
    * All time:  1109055 downloads -  spyder-kernels  2.4.2  Jupyter kernels for Spyder's console  

</details>

**Other checks:**

<details>

1. - [ ] Check the pinnings
2. - [ ] Verify that the `build_number` is correct
3. - [x] has `setuptools`
5. - [x] has `wheel`
7. - [x] `pip` in test
9. - [ ] Verify the test section
10. - [ ] Verify if the package is `architecture specific`
11. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
12.  - [x] license_file: LICENSE.txt is present

14. - [x] license_family MIT is present
16. - [x] License: MIT
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier         |
|:-------------------|
| MIT                |
| MIT-0              |
| MIT-advertising    |
| MIT-CMU            |
| MIT-enna           |
| MIT-feh            |
| MIT-Modern-Variant |
| MIT-open-group     |
| MITNFA             |
</details>

**Check dependency issues:**

<details>
../aggregate/spyder-kernels-feedstock/recipe/meta.yaml
Dependencies: ['wheel', 'ipykernel >=6.16.1,<7.0.0', 'setuptools', 'python', 'packaging', 'ipython >=7.31.1,<9.0.0', 'jupyter_client >=7.3.4,<8.0.0', 'cloudpickle', 'pip', 'pyzmq >=22.1.0']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:
- py3.7:  Encountered problems while solving:
  - nothing provides __glibc >=2.17 needed by libstdcxx-ng-11.2.0-h1234567_0
  - nothing provides __glibc >=2.17 needed by libgcc-ng-11.2.0-h1234567_0

- py3.8:  Encountered problems while solving:
  - nothing provides __glibc >=2.17 needed by libstdcxx-ng-11.2.0-h1234567_0

- py3.9:  Encountered problems while solving:
  - nothing provides __glibc >=2.17 needed by libstdcxx-ng-11.2.0-h1234567_0

- py3.10:  Encountered problems while solving:
  - nothing provides __glibc >=2.17 needed by libstdcxx-ng-11.2.0-h1234567_0


linux-ppc64le:
- py3.7:  Encountered problems while solving:
  - package ipykernel-6.19.2-py38he95b402_0 requires python >=3.8,<3.9.0a0, but none of the providers can be installed

- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-s390x:
- py3.7:  Encountered problems while solving:
  - package ipykernel-6.19.2-py38heb6ab9f_0 requires python >=3.8,<3.9.0a0, but none of the providers can be installed

- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-64:
- py3.7:  Encountered problems while solving:
  - package ipykernel-6.19.2-py38h01d92e1_0 requires python >=3.8,<3.9.0a0, but none of the providers can be installed

- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

win-64:
- py3.7:  Encountered problems while solving:
  - package ipykernel-6.19.2-py38hd4e2768_0 requires python >=3.8,<3.9.0a0, but none of the providers can be installed

- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

</details>

**Package Build Score: 17**


</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/spyder-kernels-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/spyder-kernels-feedstock/tree/2.4.2)
* [conda-forge recipe](https://github.com/conda-forge/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/spyder-kernels)
* [Diff between upstream and feature branch](https://github.com/conda-forge/spyder-kernels-feedstock/compare/main...AnacondaRecipes:2.4.2)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/spyder-kernels-feedstock/compare/master...AnacondaRecipes:2.4.2)
* [The last merged PRs](https://github.com/AnacondaRecipes/spyder-kernels-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 2.4.2 git@github.com:AnacondaRecipes/spyder-kernels-feedstock.git
```
